### PR TITLE
Add new fields in objects

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -59,6 +59,7 @@ a = {
         country: { label: "Country" },
         name: {
             label: " ",
+            addField: true,
             schema: {
                 _order: ["first", "last"],
                 first: { label: "First Name" },

--- a/example/index.html
+++ b/example/index.html
@@ -54,7 +54,7 @@ a = {
     schema: { // the types are inferred from the data above
         _order: ["age", "country", "name", "student", "hobbies", "born",
             "keyboards", "editableObject", "preferredMusicGenre",
-            "editableObjectWithPossibleAnswers"],
+            "editableObjectWithPossibleAnswers", "dateFieldWithPossibleValues"],
         age: { label: "Age", type: "number" },
         country: { label: "Country" },
         name: {
@@ -110,6 +110,16 @@ a = {
                     possible: [1, 2, 3, 4, 5]
                 }
             }
+        },
+        dateFieldWithPossibleValues: {
+            label: "Choose a date",
+            possible: [
+                new Date(2015, 7, 3),
+                new Date(2014, 8, 9),
+                new Date(2013, 3, 8),
+                new Date(2012, 1, 10),
+                new Date(2011, 10, 11)
+            ]
         }
     }
 }</textarea>

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -298,6 +298,18 @@
     }
 
     /*!
+     * knownElementaryFieldTypes
+     * An array with the known field types without `array` and `object`.
+     *
+     * @name knownElementaryFieldTypes
+     * @constant
+     * @type {Array}
+     * @default
+     */
+    var knownElementaryFieldTypes = ["number", "boolean", "string", "regexp",
+        "date"];
+
+    /*!
      * getDefaultValueForType
      * Returns a default value for the specified schema field type.
      *
@@ -525,6 +537,148 @@
                         path: field.path + "." + k,
                         _edit: field.edit
                     })));
+                }
+
+                    var $nameInput = $("<input>", {
+                        type: "text"
+                    });
+
+                    var $typeSelect = $("<select>", {
+                        on: {
+                            change: function () {
+                                var val = $(this).val();
+                                var $clone = JsonEdit.inputs[val].clone();
+                                $possibleValueInput.replaceWith($clone);
+                                $possibleValueInput = $clone;
+                            }
+                        }
+                    });
+                    for (var i = 0; i < knownElementaryFieldTypes.length; i++) {
+                        $typeSelect.append($("<option>", {
+                            value: knownElementaryFieldTypes[i],
+                            text: knownElementaryFieldTypes[i]
+                        }));
+                    }
+
+                    var $labelInput = $("<input>", {
+                        type: "text"
+                    });
+
+                    var $possibleValuesDiv = $("<div>", {
+                        css: {
+                            display: "none"
+                        }
+                    });
+
+                    var $possibleValuesSelect = $("<select>", {
+                        multiple: "multiple"
+                    });
+
+                    var $checkboxPossibleValues = $("<input>", {
+                        type: "checkbox",
+                        on: {
+                            change: function (e) {
+                                $possibleValuesDiv.toggle(this.checked);
+                            }
+                        }
+                    });
+
+                    var $possibleValueInput = $("<input>", {
+                    });
+
+                    var $addPossibleValueButton = $("<input>", {
+                        type: "button",
+                        value: "+ Add possible value",
+                        on: {
+                            click: function () {
+                                var val = $possibleValueInput.val()
+                                $possibleValuesSelect.append($("<option>", {
+                                    value: val,
+                                    text: val
+                                }));
+                            }
+                        }
+                    });
+
+                    /*!
+                     * nameAlreadyExists
+                     * A function that determines whether the given name
+                     * already exists in a field under the path in which the
+                     * user tries to create a new field.
+                     *
+                     * @name nameAlreadyExists
+                     * @function
+                     * @param {String} name The name of the field to search for.
+                     * @return {Boolean} True if the name already exists, false
+                     * otherwise.
+                     */
+                    function nameAlreadyExists(name) {
+                        // Convert the array of jQuery elements to a jQuery
+                        // object with multiple elements.
+                        var $input2 = $($.map($input,
+                                    function (e) { return e.get(0); }));
+
+                        // Obtain the data at the path where the new field is
+                        // created.
+                        var data = self.getData(field.path, $input2);
+
+                        // Return true if the given name is already in the
+                        // data, otherwise return false.
+                        return Object.keys(data).indexOf(name) > -1;
+                    }
+
+                    var $addFieldButton = $("<input>", {
+                        type: "button",
+                        value: "+ Add field",
+                        on: {
+                            click: function () {
+                                $nameInput.val($nameInput.val()
+                                        .replace(/\./g, "").trim());
+                                $labelInput.val($labelInput.val().trim());
+
+                                var name = $nameInput.val();
+                                var label = $labelInput.val();
+                                var type = $typeSelect.val();
+
+                                // Validate.
+                                if (name === "+" || name.length === 0 ||
+                                        nameAlreadyExists(name)) {
+                                    alert("The name of the field should be a" +
+                                            " non-empty string without dots, " +
+                                            "different than \"+\" and not " +
+                                            "already existing under the " +
+                                            "path \"" + field.path + "\".");
+                                    return;
+                                }
+                                if (label.length === 0) {
+                                    alert("The label of the field should be " +
+                                            "a non-empty string.");
+                                }
+
+                                var path = field.path + "." + name;
+                                $div.before(self.createGroup({
+                                    name: name,
+                                    label: label,
+                                    type: type,
+                                    path: path
+                                }));
+                            }
+                        }
+                    });
+
+                    $div.append($("<hr>"),
+                            $("<strong>").text("Add field"),
+                            $("<br>"),
+                            $("<label>").text("Name: ").append($nameInput),
+                            $("<label>").text("Type: ").append($typeSelect),
+                            $("<label>").text("Label: ").append($labelInput),
+                            $("<br>"),
+                            $("<label>").text("Enable possible values: ")
+                                .append($checkboxPossibleValues),
+                            $possibleValuesDiv.append($possibleValuesSelect,
+                                $possibleValueInput, $addPossibleValueButton),
+                            $addFieldButton);
+                    $input.push($div);
                 }
             } else {
                 // If the field data is not specified, use a default value.

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -539,6 +539,9 @@
                     })));
                 }
 
+                if (field.addField) {
+                    var $div = $("<div>");
+
                     var $nameInput = $("<input>", {
                         type: "text"
                     });
@@ -662,6 +665,12 @@
                                     type: type,
                                     path: path
                                 }));
+
+                                $nameInput.add($labelInput, $typeSelect,
+                                        $possibleValueInput).val(null);
+                                $possibleValuesSelect.empty();
+                                $checkboxPossibleValues.prop("checked", false)
+                                    .trigger("change");
                             }
                         }
                     });

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -546,6 +546,10 @@
                         type: "text"
                     });
 
+                    var $possibleValuesSelect = $("<select>", {
+                        multiple: "multiple"
+                    });
+
                     var $typeSelect = $("<select>", {
                         on: {
                             change: function () {
@@ -554,6 +558,7 @@
                                     .attr("data-json-editor-type", type);
                                 $possibleValueInput.replaceWith($clone);
                                 $possibleValueInput = $clone;
+                                $possibleValuesSelect.empty();
                             }
                         }
                     });
@@ -572,10 +577,6 @@
                         css: {
                             display: "none"
                         }
-                    });
-
-                    var $possibleValuesSelect = $("<select>", {
-                        multiple: "multiple"
                     });
 
                     var $checkboxPossibleValues = $("<input>", {

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -664,7 +664,7 @@
                                 $labelInput.val($labelInput.val().trim());
 
                                 var name = $nameInput.val();
-                                var label = $labelInput.val();
+                                var label = $labelInput.val() || name;
 
                                 // Validate.
                                 if (name === "+" || name.length === 0 ||
@@ -675,10 +675,6 @@
                                             "already existing under the " +
                                             "path \"" + field.path + "\".");
                                     return;
-                                }
-                                if (label.length === 0) {
-                                    alert("The label of the field should be " +
-                                            "a non-empty string.");
                                 }
 
                                 var newSchema = {
@@ -716,7 +712,7 @@
                             $("<br>"),
                             $("<label>").text("Name: ").append($nameInput),
                             $("<label>").text("Type: ").append($typeSelect),
-                            $("<label>").text("Label (without final semicolon): ").append($labelInput),
+                            $("<label>").text("Label (optional, without final semicolon): ").append($labelInput),
                             $("<br>"),
                             $("<label>").text("Enable possible values: ")
                                 .append($checkboxPossibleValues),

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -558,6 +558,8 @@
                                     .attr("data-json-editor-type", type);
                                 $possibleValueInput.replaceWith($clone);
                                 $possibleValueInput = $clone;
+                                self.setValueToElement($possibleValueInput,
+                                        getDefaultValueForType(type));
                                 $possibleValuesSelect.empty();
                             }
                         }
@@ -654,7 +656,6 @@
 
                                 var name = $nameInput.val();
                                 var label = $labelInput.val();
-                                var type = $typeSelect.val();
 
                                 // Validate.
                                 if (name === "+" || name.length === 0 ||
@@ -671,19 +672,31 @@
                                             "a non-empty string.");
                                 }
 
-                                var path = field.path + "." + name;
-                                $div.before(self.createGroup({
+                                var newSchema = {
                                     name: name,
                                     label: label,
-                                    type: type,
-                                    path: path
-                                }));
+                                    type: $typeSelect.val(),
+                                    path: field.path + "." + name
+                                };
+                                if ($checkboxPossibleValues.prop("checked")) {
+                                    var possibleValues = [];
+                                    var converter = self.converters[newSchema.type];
+                                    $possibleValuesSelect.children("option").each(
+                                        function (i, e) {
+                                            possibleValues.push(converter
+                                                                ($(e).val()));
+                                        });
+                                    newSchema.possible = possibleValues;
+                                }
+
+                                $div.before(self.createGroup(newSchema));
 
                                 $nameInput.add($labelInput, $typeSelect,
                                         $possibleValueInput).val(null);
                                 $possibleValuesSelect.empty();
                                 $checkboxPossibleValues.prop("checked", false)
                                     .trigger("change");
+                                $typeSelect.trigger("change");
                             }
                         }
                     });
@@ -694,7 +707,7 @@
                             $("<br>"),
                             $("<label>").text("Name: ").append($nameInput),
                             $("<label>").text("Type: ").append($typeSelect),
-                            $("<label>").text("Label: ").append($labelInput),
+                            $("<label>").text("Label (without comma): ").append($labelInput),
                             $("<br>"),
                             $("<label>").text("Enable possible values: ")
                                 .append($checkboxPossibleValues),

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -707,7 +707,7 @@
                             $("<br>"),
                             $("<label>").text("Name: ").append($nameInput),
                             $("<label>").text("Type: ").append($typeSelect),
-                            $("<label>").text("Label (without comma): ").append($labelInput),
+                            $("<label>").text("Label (without final semicolon): ").append($labelInput),
                             $("<br>"),
                             $("<label>").text("Enable possible values: ")
                                 .append($checkboxPossibleValues),

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -606,6 +606,16 @@
                         }
                     });
 
+                    var $deletePossibleValueButton = $("<input>", {
+                        type: "button",
+                        value: "× Delete selected possible values",
+                        on: {
+                            click: function () {
+                                $possibleValuesSelect.children("option:selected").remove();
+                            }
+                        }
+                    });
+
                     /*!
                      * nameAlreadyExists
                      * A function that determines whether the given name
@@ -689,7 +699,8 @@
                             $("<label>").text("Enable possible values: ")
                                 .append($checkboxPossibleValues),
                             $possibleValuesDiv.append($possibleValuesSelect,
-                                $possibleValueInput, $addPossibleValueButton),
+                                $possibleValueInput, $addPossibleValueButton,
+                                $deletePossibleValueButton),
                             $addFieldButton);
                     $input.push($div);
                 }

--- a/src/jquery-json-editor.js
+++ b/src/jquery-json-editor.js
@@ -252,8 +252,17 @@
             if (!obj.hasOwnProperty(k) || k === ORDER_PROPERTY) continue;
 
             var c = obj[k];
-            if (schemaContainsMoreFields(c)) {
+            var _schemaContainsMoreFields = schemaContainsMoreFields(c);
+            // If the schema contains more fields
+            if (_schemaContainsMoreFields) {
+                // recursively process them
                 schemaCoreFields(c.schema, path + k + ".");
+
+            // If the type is not specified but a non-empty array of
+            // possible values is specified
+            } else if (!c.type && c.possible) {
+                // set the type obtained by analyzing the first possible value
+                c.type = getTypeOf(c.possible[0]);
             }
             c.label = c.label || k;
             c.path = path + k;
@@ -261,7 +270,7 @@
 
             // If the `c` schema contains more fields and it does not have the
             // order of its fields specified,
-            if (schemaContainsMoreFields(c) &&
+            if (_schemaContainsMoreFields &&
                     !Array.isArray(Object(c.schema)[ORDER_PROPERTY])) {
                 c.schema = c.schema || {};
                 // Generate the default order of its fields using Object.keys.
@@ -1116,7 +1125,7 @@
             return new RegExp(value);
         },
         date: function (value) {
-            return new Date(value);
+            return new Date(value + " UTC");
         }
     };
 


### PR DESCRIPTION
See #7.

- New: possibility to add new fields to objects. Currently you cannot add new fields to arrays, just to objects.
- Add a new field to the example, `dateFieldWithPossibleValues`.
- In `schemaCoreFields` function infer the type of a field that does not have more fields in it from the first possible value, if given.
- In the converter for the "date" type interpret the given string as a UTC date (this solves an issue that would make the generated JSON in the example contain wrong dates).